### PR TITLE
Add option to disable webgl2 - Maybe redundant?

### DIFF
--- a/data/html/options-panel.html
+++ b/data/html/options-panel.html
@@ -383,6 +383,11 @@
 		</p>
 
 		<p>
+			<input type="checkbox" id="webgl2" data-invertvalue="true" data-prefname="webgl.enable-webgl2" />
+			<label for="webgl">Disable webGL2</label>
+		</p>
+
+		<p>
 			<input type="checkbox" id="webrtc" data-invertvalue="true" data-prefname="media.peerconnection.enabled" />
 			<label for="webrtc">Disable webRTC</label>
 		</p>

--- a/data/json/useragents.json
+++ b/data/json/useragents.json
@@ -489,7 +489,7 @@
 							"da-DK":"da,en-US;q=0.7,en;q=0.3",
 							"de-DE":"de,en-US;q=0.7,en;q=0.3",
 							"en-US":"en-US,en;q=0.5",
-							"es-ES":"es-ES,es;q=0.8,en-US;q=0.5,en;q=0.3",
+							"es-ES":"es-CL,es;q=0.8,en-US;q=0.5,en;q=0.3",
 							"fr-FR":"fr,fr-FR;q=0.8,en-US;q=0.5,en;q=0.3",
 							"it-IT":"it-IT,it;q=0.8,en-US;q=0.5,en;q=0.3",
 							"ja":"ja,en-US;q=0.7,en;q=0.3",

--- a/lib/Panel.js
+++ b/lib/Panel.js
@@ -196,6 +196,7 @@ function setupPanel() {
 		[ 'setCheckBox', 'winname', PrefServ.getter('extensions.agentSpoof.windowName') ],
 		[ 'setCheckBox', 'canvas', PrefServ.getter('extensions.agentSpoof.canvas') ],
 		[ 'setCheckBox', 'webrtc', !(PrefServ.getter('media.peerconnection.enabled')) ],
+		[ 'setCheckBox', 'webgl2', !(PrefServ.getter('webgl.enable-webgl2')) ],
 		[ 'setCheckBox', 'auth', PrefServ.getter('extensions.agentSpoof.authorization') ],
 		[ 'setCheckBox', 'browsing_downloads', !(PrefServ.getter('places.history.enabled')) ],
 		[ 'setCheckBox', 'whitelist_enabled', !(PrefServ.getter('extensions.agentSpoof.whiteListDisabled')) ],

--- a/lib/PrefServ.js
+++ b/lib/PrefServ.js
@@ -36,6 +36,7 @@ function getTogglePrefs(){
 		'plugins.click_to_play',
 		'places.history.enabled',
 		'pdfjs.disabled',
+		'webgl.enable-webgl2'
 		'browser.search.suggest.enabled',
 		'dom.enable_performance',
 		'dom.enable_resource_timing',


### PR DESCRIPTION
webgl.enable-webgl2 remains enabled when webgl.disabled;true so I dunno